### PR TITLE
T3.x SPI pins MOSI/SCK not DC...

### DIFF
--- a/ST7735_t3.h
+++ b/ST7735_t3.h
@@ -371,6 +371,7 @@ class ST7735_t3 : public Print
   uint8_t  tabcolor;
 
   void     spiwrite(uint8_t),
+  		   spiwrite16(uint16_t d),
            writecommand(uint8_t c),
            writecommand_last(uint8_t c),
            writedata(uint8_t d),


### PR DESCRIPTION
Before this would always go to bitbang...

But with this one, it uses _pspi->transfer() if it detects this.

Also sped up, that if we call transfer16, have new function spiwrite16, that if possible calls _pspi->transfer16()  which speeds things up...